### PR TITLE
Remove data from category_group when cleaning catalog.

### DIFF
--- a/pscleaner.php
+++ b/pscleaner.php
@@ -412,6 +412,7 @@ class PSCleaner extends Module
 				$tables = array(
 					'product',
 					'product_shop',
+					'category_group',
 					'feature_product',
 					'product_lang',
 					'category_product',


### PR DESCRIPTION
This allows to recreate group with the same id without any issues.
